### PR TITLE
Adjust workaround to allow component objects.

### DIFF
--- a/lib/src/vfjs-field-component/index.js
+++ b/lib/src/vfjs-field-component/index.js
@@ -10,7 +10,7 @@ const VueFormJsonSchemaFieldComponent = {
   render() {
     return vfjsHelperCreateElement(
       // TODO remove workaround and add a method like vfjsFieldHelperIsNativeComponent to detect components that don't have to be resolved
-      (fieldNativeComponentsNoResolve.includes(this.vfjsComponent) ? this.vfjsComponent : resolveComponent(this.vfjsComponent)),
+      (typeof this.vfjsComponent !== 'string' || fieldNativeComponentsNoResolve.includes(this.vfjsComponent) ? this.vfjsComponent : resolveComponent(this.vfjsComponent)),
       {
         ...this.getVfjsAttributes(),
       },


### PR DESCRIPTION
The vfjsComponent field can be a component object in addition to a string component name. When it's an object, the workaround here was causing an error to be thrown from the resolveComponent function. This fixes it to bypass the resolveComponent function if it's not a string.